### PR TITLE
New python trade library, backpack.py change

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The purpose of this document is to provide a quick overview over existing packag
 - [steamodd](https://github.com/Lagg/steamodd) - Steam tools library.
 - [steampy](https://github.com/bukson/steampy) - Fully automated Steam trade offers library with SteamGuard support.
 - [SteamAPI](https://github.com/smiley/steamapi) - An object-oriented Python 2.7+ library for accessing the Steam Web API.
+- [Steam-Trade](https://github.com/Zwork101/steam-trade) - An asynchronous, event based python steam trade lib
 
 #### Game Interaction
 
@@ -132,7 +133,7 @@ The purpose of this document is to provide a quick overview over existing packag
 
 #### Misc
 
-- [backpack.py](https://github.com/Zwork101/backpack.py) - Library for interacting with backpack.tf.
+- [backpack.py](https://github.com/Zwork101/backpack.py) - Library for interacting with backpack.tf. (Not Maintained)
 - [vpk](https://github.com/ValvePython/vpk) - Python module for working with Valve's Pack format.
 - [vdf](https://github.com/ValvePython/vdf) - Python module for working with Valve's KeyValue format.
 


### PR DESCRIPTION
I created a new python trade library called Steam-Trade: https://github.com/Zwork101/steam-trade and have stopped maintaining backpack.py, wasn't sure wether to remove it or label it.