### PR TITLE
PR title: Add Video Game Backlog (Steam backlog analyzer) under Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The purpose of this document is to provide a quick overview over existing packag
 - [SteamDesktopAuthenticator](https://github.com/Jessecar96/SteamDesktopAuthenticator) - Desktop implementation of Steam's mobile authenticator app.
 - [protonenv](https://github.com/rizkiarm/protonenv) - Simple Proton version and prefix management.
 - [steam-desktop-authenticator-multiplatform](https://github.com/tre3p/steam-desktop-authenticator-multiplatform) - Steam desktop authenticator.
+- [Video Game Backlog](https://www.videogamebacklog.com/analyze) - Steam library analyzer: paste a public profile (URL, vanity, or SteamID64) to see interesting statistics.
 
 ### Discussion Boards
 


### PR DESCRIPTION
Adds Video Game Backlog's free Steam backlog analyzer.

- Reads a public Steam library via the official Web API. No OAuth, no login, read-only
- Surfaces never-launched games, playtime in context, dormant games, and a projected clear date
- No account required, nothing is written to a database

Placed under Tools. Happy to adjust wording or section to match the list's conventions.